### PR TITLE
fix: change icon-minicart wrapper container width heigth and padding

### DIFF
--- a/minimum-boilerplate-theme/styles/css/header/minicart/vtex.minicart.css
+++ b/minimum-boilerplate-theme/styles/css/header/minicart/vtex.minicart.css
@@ -5,7 +5,9 @@
 }
 
 .minicartWrapperContainer {
-    width: 40px;
+    width: 1.5rem;
+    height: 1.5rem;
+    padding-right: 3rem;
 }
 
 .openIconContainer {


### PR DESCRIPTION
 **fix:**<!--- title -->change icon-minicart wrapper container
|--> **description:**<!---add drop-down menu for categories with redirect.--> adjust  width, height and padding of the icon-minicart wrapper container,
|--> **How to test it?:** <!--- Don't forget to add a link to a Workspace where this branch is linked -->[Workspace](https://mariavillalobos--itgloberspartnercl.myvtex.com/!)
|--> **How does this PR make you feel?:

<img src="https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdTh4NXplZDBxcGV0dThvOWQ5eHd4amoyNXN3bjhqcnkxb2F3dzRmbCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/VIfE4DE7vY49i/giphy.gif" width= 300 height=300 />

|--> **Screenshots or example usage:**<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images, use only browser of GitHub--> N/A
|--> **Does it depend on another component?:** <!---if depent of any apps--> N/A						
|--> **url-custom-apps:** <!---link a apps donde los proyectos necesiten de ellas para	funcionar.--> N/A
|--> **name-element-additional:** <!--mensaje-elemento-adicional.--> N/A