### PR TITLE
fix: adjust position of the minicart empty state checkout box and mobile minicart elements

### DIFF
--- a/minimum-boilerplate-theme/store/blocks/global/components/header/minicart/minicart.jsonc
+++ b/minimum-boilerplate-theme/store/blocks/global/components/header/minicart/minicart.jsonc
@@ -154,7 +154,9 @@
       "horizontalAlign": "center",
       "verticalAlign": "middle",
       "rowGap": 0,
-      "blockClass": "global__ckeckout__empty-state"
+      "blockClass": [
+        "global__ckeckout__empty-state"
+      ]
     }
   }
 }

--- a/minimum-boilerplate-theme/styles/css/header/minicart/vtex.flex-layout.css
+++ b/minimum-boilerplate-theme/styles/css/header/minicart/vtex.flex-layout.css
@@ -1,15 +1,15 @@
 .flexRow--global__minicart-footer {
-    max-width        : 100vw;
-    min-width        : 368px;
+    max-width           : 100vw;
+    min-width           : 368px;
     /* width            : 100%; */
-    height           : 126px;
-    /* margin-left   : 13px; */
-    margin           : auto;
-    border           : 1px solid rgba(231, 231, 231, 1);
-    box-shadow       : none;
-    flex-shrink      : 0;
-    align-content    : center;
-    /* margin-left   : 0.8rem; */
+    height              : 126px;
+    /* margin-left      : 13px; */
+    margin              : auto;
+    border              : 1px solid rgba(231, 231, 231, 1);
+    box-shadow          : none;
+    flex-shrink         : 0;
+    align-content       : center;
+    /* margin-left      : 0.8rem; */
 }
 
 
@@ -48,17 +48,16 @@
     padding-bottom: 1rem;
 }
 
-/* .flexRowContent--desktop__list-row .stretchChildrenWidth,
+.flexRowContent--desktop__list-row .stretchChildrenWidth,
 .flexRowContent--mobile__list-row .stretchChildrenWidth {
     padding-right: 0;
-    width: 100% !important;
-} */
+}
 
 
 .flexColChild--minicart-empty-row-wrapper:first-child {
-    display        : flex;
-    flex-direction : column;
-    justify-content: start;
+    display           : flex;
+    flex-direction    : column;
+    justify-content   : start;
     /* height         : calc(100% - 10rem); */
 }
 
@@ -92,3 +91,21 @@
 /* .flexCol--minicart-empty-row-wrapper {
     height: 90vh;
 } */
+
+/* .flexCol--global__ckeckout__empty-state {
+    height     : 200px;
+} */
+
+@media screen and (max-width: 1025px) {
+    .flexCol--global__ckeckout__empty-state {
+        position   : absolute;
+        /* top     : 21rem; */
+        bottom     : 0px;
+        height     : 200px;
+    }
+
+    .flexRow--global__minicart-footer {
+        min-width: 328px;
+        margin: auto;
+    }
+}

--- a/minimum-boilerplate-theme/styles/css/header/minicart/vtex.minicart.css
+++ b/minimum-boilerplate-theme/styles/css/header/minicart/vtex.minicart.css
@@ -5,8 +5,8 @@
 }
 
 .minicartWrapperContainer {
-    width: 1.5rem;
-    height: 1.5rem;
+    width        : 1.5rem;
+    height       : 1.5rem;
     padding-right: 3rem;
 }
 
@@ -82,6 +82,22 @@
 .minicartSideBarContentWrapper {
     height  : calc(100% - 5rem) !important;
     position: fixed;
+}
+
+@media screen and (max-width: 1025px) {
+    .minicartSideBarContentWrapper {
+        height  : 100% !important;
+        position: fixed;
+    }
+
+    .minicartContentContainer--mobile__minicart-base-content{
+        margin: auto;
+    }
+
+    .minicartCheckoutButton :global(.vtex-button) {
+        min-width       : 328px;
+        
+    }
 }
 
 .minicartProductListContainer--global__minicart-product-list {

--- a/minimum-boilerplate-theme/styles/css/home/vtex.my-account.css
+++ b/minimum-boilerplate-theme/styles/css/home/vtex.my-account.css
@@ -1,6 +1,6 @@
 :global(.vtex-slider-layout-0-x-paginationDot--isActive~.vtex-slider-layout-0-x-paginationDot:after) {
     width           : 44px;
-    height          : 2px;
+    height          : 1px;
     content         : "";
     font-size       : 0;
     background-color: rgba(0, 0, 0, .4);

--- a/minimum-boilerplate-theme/styles/css/home/vtex.slider-layout.css
+++ b/minimum-boilerplate-theme/styles/css/home/vtex.slider-layout.css
@@ -15,7 +15,7 @@
 
 .paginationDot::after {
     width           : 44px;
-    height          : 2px;
+    height          : 1px;
     content         : "";
     font-size       : 0;
     background-color: #1D2734;
@@ -80,8 +80,11 @@
     padding: 0rem 0.3rem;
 }
 
+.paginationDot--first-carousel--text {
+    margin-right: 0.2rem;
+}
 
-@media screen and (max-width: 1024px) {
+@media screen and (max-width: 1025px) {
     .paginationDot {
         width : 16px !important;
         height: 14px !important;
@@ -90,4 +93,9 @@
     .paginationDotsContainer {
         bottom: -61px;
     }
+
+    .paginationDot::after {
+        width           : 27px;
+    }
 }
+


### PR DESCRIPTION
**fix:** adjust position of the minicart empty state checkout box and align elements on the mobile minicart.
|--> **description:**<!--add drop-down menu for categories with redirect.--> adjust position of the minicart empty state checkout box and align elements on the mobile minicart.
|--> **How to test it?:** <!--- Don't forget to add a link to a Workspace where this branch is linked -->[Workspace](https://mariavillalobos--itgloberspartnercl.myvtex.com/!)
|--> **How does this PR make you feel?:

<img src="https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbXZhOHJqYzJrazRldWhyanN6bTg2cnN6a2lheWZqNzZsbXFxaHR1diZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fBEMsUeGHdpsClFsxM/giphy.gif" width= 300 height=300 />

|--> **Screenshots or example usage:**<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images, use only browser of GitHub--> N/A
|--> **Does it depend on another component?:** <!---if depent of any apps--> N/A						
|--> **url-custom-apps:** <!---link a apps donde los proyectos necesiten de ellas para	funcionar.--> N/A
|--> **name-element-additional:** <!--mensaje-elemento-adicional.--> N/A